### PR TITLE
fix typo of reykjavik

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ To install the theme:
 
 To use the white-sand theme when starting emacs, add this to your init.el:
 
-    (load-theme 'reykjakik)
+    (load-theme 'reykjavik)


### PR DESCRIPTION
Originally this was typed as 'reykjakik' but after trying to put that into my .emacs file, it did not work but entering in 'reykjavic' did. I assumed that this was a typo and was intended to be 'reykjavik'. If this is not the case and I am overlooking something, I apologize. 
